### PR TITLE
Generate comment with original module name next to inlined module, e.g. for webpack watching & rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ It inserts the __content__ of the _imported file_ directly into the _importing f
 
 ## Caveats
 
-Babel does not track dependency between _imported_ and _importing_ files after the transformation is made. Therefore, you need to change the _importing file_ in order to see your changes in the _imported file_ spread. To overcome this, you can:
+Babel does not track dependency between _imported_ and _importing_ files after the transformation is made. Therefore, you need to change the _importing file_ in order to see your changes in the _imported file_ spread. To overcome this:
 
-* Disable babel cache (`BABEL_DISABLE_CACHE=1`)
+* If you are using `babel-node` or `babel-register`, you can [disable babel cache (`BABEL_DISABLE_CACHE=1`)](https://babeljs.io/docs/usage/babel-register/#environment-variables-babel-disable-cache).
+* If you are using webpack with `babel-loader`, you can use [babel-inline-import-loader](https://github.com/elliottsj/babel-inline-import-loader).
 
 Also make sure that your task runner is watching for changes in the _imported file_ as well. You can see it working [here](https://github.com/Quadric/perfect-graphql-starter/blob/master/nodemon.json).
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register",
     "test-watch": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register --watch",
     "lint-js": "eslint plugin",
-    "prepublish": "babel -d build/ plugin/"
+    "prepare": "babel -d build/ plugin/"
   },
   "dependencies": {
     "require-resolve": "0.0.2"

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -25,9 +25,17 @@ export default function({ types: t }) {
                 const content = BabelInlineImportHelper.getContents(givenPath, reference);
                 const variable = t.variableDeclarator(t.identifier(id), t.stringLiteral(content));
 
-                path.replaceWith(
-                  t.variableDeclaration('const', [variable])
-                );
+                path.replaceWith({
+                  type: 'VariableDeclaration',
+                  kind: 'const',
+                  declarations: [variable],
+                  leadingComments: [
+                    {
+                      type: 'CommentBlock',
+                      value: ` babel-plugin-inline-import '${givenPath}' `
+                    }
+                  ]
+                });
               }
             }
           }

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -9,7 +9,7 @@ describe('Babel Inline Import - Plugin', () => {
         plugins: [BabelInlineImportPlugin]
       });
 
-      expect(transformedCode.code).to.equal(`var SomeExample = 'a raw content\\n';`);
+      expect(transformedCode.code).to.equal(`/* babel-plugin-inline-import './fixtures/example.raw' */var SomeExample = 'a raw content\\n';`);
     });
 
     it('accepts different extensions', () => {
@@ -24,7 +24,7 @@ describe('Babel Inline Import - Plugin', () => {
         ]]
       });
 
-      expect(transformedCode.code).to.equal(`var SomeExample = 'print 1 + 1\\n';`);
+      expect(transformedCode.code).to.equal(`/* babel-plugin-inline-import './fixtures/example.py' */var SomeExample = 'print 1 + 1\\n';`);
     });
 
     it('throws error when importing with destructuring', () => {


### PR DESCRIPTION
With these changes, a comment is generated before the inlined module to allow other tools to find out the original module name.

For example, webpack can use this to mark the original modules as dependencies for watching those files and rebuilding when the content changes. I've made a webpack loader which does exactly that: https://github.com/elliottsj/babel-inline-import-loader

That loader depends on these changes in order to work; I'd love to get some opinions on this approach.

I've also changed the npm script from "prepublish" to "prepare" so that the script is run when [installing the package from git](https://github.com/elliottsj/babel-inline-import-loader/blob/3c1c60cc7073f4cd2e70b4f1de3ed46aaf5d8648/package.json#L20) (made testing a bit easier). I can remove this or put it in another PR if you like.