### PR TITLE
Remove Meteor code that is no longer needed

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -16,11 +16,6 @@ export default function({ types: t }) {
                   throw new Error(`Destructuring inlined import is not allowed. Check the import statement for '${givenPath}'`);
                 }
 
-                // Here we detect the use of Meteor by checking global.meteorBabelHelpers
-                if(global.meteorBabelHelpers && BabelInlineImportHelper.hasRoot(reference)) {
-                  reference = BabelInlineImportHelper.transformRelativeToRootPath(reference);
-                }
-
                 const id = path.node.specifiers[0].local.name;
                 const content = BabelInlineImportHelper.getContents(givenPath, reference);
                 const variable = t.variableDeclarator(t.identifier(id), t.stringLiteral(content));


### PR DESCRIPTION
Starting with the just-released Meteor 1.7, this code block seems to be unnecessary, and causes problems. `reference` is already resolved to an absolute path at this point, so the path becomes incorrect. See https://github.com/meteor/meteor/issues/9919#issuecomment-393628638

This change will break older Meteor so this either needs to be a major NPM release, or we'd have to figure out how to check the Meteor version in this `if` block.