### PR TITLE
Fix transformation of `import * as x from ...` to behave correctly

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -16,9 +16,16 @@ export default function({ types: t }) {
                   throw new Error(`Destructuring inlined import is not allowed. Check the import statement for '${givenPath}'`);
                 }
 
-                const id = path.node.specifiers[0].local.name;
+                const specifier = path.node.specifiers[0];
+                const id = specifier.local.name;
                 const content = BabelInlineImportHelper.getContents(givenPath, reference);
-                const variable = t.variableDeclarator(t.identifier(id), t.stringLiteral(content));
+
+                let variableValue = t.stringLiteral(content);
+                // import * as x from ...
+                if (specifier.type === 'ImportNamespaceSpecifier') {
+                  variableValue = t.objectExpression([t.objectProperty(t.identifier('default'), variableValue)]);
+                }
+                const variable = t.variableDeclarator(t.identifier(id), variableValue);
 
                 path.replaceWith({
                   type: 'VariableDeclaration',

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -3,7 +3,7 @@ import * as babel from '@babel/core';
 
 describe('Babel Inline Import - Plugin', () => {
   describe('Babel Plugin', () => {
-    it('transforms the import statement into a variable with the intended content', () => {
+    it('transforms the import default statement into a variable with the intended content', () => {
       const transformedCode = babel.transform(
         "import SomeExample from './fixtures/example.raw';",
         {
@@ -16,6 +16,23 @@ describe('Babel Inline Import - Plugin', () => {
 
 /* babel-plugin-inline-import './fixtures/example.raw' */
 const SomeExample = "a raw content\\n";`);
+    });
+
+    it('transforms the import namespace statement into a variable with the intended content in property "default"', () => {
+      const transformedCode = babel.transform(
+        "import * as SomeExample from './fixtures/example.raw';",
+        {
+          filename: __filename,
+          plugins: [BabelInlineImportPlugin]
+        }
+      );
+
+      expect(transformedCode.code).to.equal(`"use strict";
+
+/* babel-plugin-inline-import './fixtures/example.raw' */
+const SomeExample = {
+  default: "a raw content\\n"
+};`);
     });
 
     it('accepts different extensions', () => {


### PR DESCRIPTION
`import * as x from 'my-module'` imports entire module's contents into
variable `x`. This is represented as ImportDeclaration with
ImportNamespaceSpecifier in Babel AST.

In the current state, this import is transformed in the same way as a
default import (`import x from 'my-module'`) and import of a single export
(`import { x } from 'my-module'`). However, this is incorrect because in
ES modules `import * as x 'my-module'` creates an object with all the
exports of 'my-module'. If 'my-module' contains only the default
export, variable `x` should contain an object with a single property:
`default`.

A raw file is not an ES module, but since we're using `import` syntax
for including it into a module, it should mimics behaviour of importing
an ES module with the default export. That's also how webpack's
raw-loader behaves.

Of course it doesn't make much sense to use this type of import for
"importing" raw files, unless you use something like "import-all.macro"
for importing multiple files that match a glob pattern. And at the same
time you need the import to result in the same thing as when using
webpack's raw-loader or jest-raw-loader.